### PR TITLE
Add Zone Transfer Request/Accept

### DIFF
--- a/src/main/scala/pt/tecnico/dsi/designate/models/Status.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/models/Status.scala
@@ -8,6 +8,7 @@ case object Status extends Enum[Status] {
   implicit val circeEncoder: Encoder[Status] = Circe.encoderUppercase(this)
   implicit val circeDecoder: Decoder[Status] = Circe.decoderUppercaseOnly(this)
 
+  case object Complete extends Status
   case object Error   extends Status
   case object Pending extends Status
   case object Active  extends Status

--- a/src/main/scala/pt/tecnico/dsi/designate/models/ZoneTransferAccept.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/models/ZoneTransferAccept.scala
@@ -1,6 +1,7 @@
 package pt.tecnico.dsi.designate.models
 
-import java.time.OffsetDateTime
+import java.time.{LocalDateTime, OffsetDateTime}
+
 import io.circe.Codec
 import io.circe.derivation.{deriveCodec, renaming}
 
@@ -9,11 +10,11 @@ object ZoneTransferAccept {
 }
 
 case class ZoneTransferAccept (
-  key: String,
+  key: Option[String],
   status: Status,
   projectId: String,
   zoneId: String,
-  createdAt: OffsetDateTime,
-  updatedAt: Option[OffsetDateTime],
+  createdAt: LocalDateTime,
+  updatedAt: Option[LocalDateTime],
   zoneTransferRequestId: String
 )

--- a/src/main/scala/pt/tecnico/dsi/designate/models/ZoneTransferRequest.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/models/ZoneTransferRequest.scala
@@ -1,12 +1,22 @@
 package pt.tecnico.dsi.designate.models
 
-import java.time.OffsetDateTime
+import java.time.{LocalDateTime, OffsetDateTime}
+
 import io.circe.Codec
 import io.circe.derivation.{deriveCodec, renaming}
 
 object ZoneTransferRequest {
   implicit val codec: Codec.AsObject[ZoneTransferRequest] = deriveCodec[ZoneTransferRequest](renaming.snakeCase, false, None)
 }
+
+object ZoneTransferRequestCreate {
+  implicit val codec: Codec.AsObject[ZoneTransferRequestCreate] = deriveCodec[ZoneTransferRequestCreate](renaming.snakeCase, false, None)
+}
+
+case class ZoneTransferRequestCreate(
+  description: String,
+  targetProjectId: Option[String]
+)
 
 case class ZoneTransferRequest (
   key: String,
@@ -15,9 +25,9 @@ case class ZoneTransferRequest (
   zoneId: String,
   description: String,
   zoneName: String,
-  createdAt: OffsetDateTime,
-  updatedAt: Option[OffsetDateTime],
+  createdAt: LocalDateTime,
+  updatedAt: Option[LocalDateTime],
   targetProjectId: Option[String],
-  version: Integer,
-  zoneTransferRequestId: String
+  // Official API says `version` should appear, but does not :/
+  // version: Integer,
 )

--- a/src/main/scala/pt/tecnico/dsi/designate/models/ZoneTransferRequest.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/models/ZoneTransferRequest.scala
@@ -6,12 +6,21 @@ import io.circe.Codec
 import io.circe.derivation.{deriveCodec, renaming}
 
 object ZoneTransferRequest {
-  implicit val codec: Codec.AsObject[ZoneTransferRequest] = deriveCodec[ZoneTransferRequest](renaming.snakeCase, false, None)
+  implicit val codec: Codec.AsObject[ZoneTransferRequest] = deriveCodec[ZoneTransferRequest](renaming.snakeCase)
 }
 
 object ZoneTransferRequestCreate {
-  implicit val codec: Codec.AsObject[ZoneTransferRequestCreate] = deriveCodec[ZoneTransferRequestCreate](renaming.snakeCase, false, None)
+  implicit val codec: Codec.AsObject[ZoneTransferRequestCreate] = deriveCodec[ZoneTransferRequestCreate](renaming.snakeCase)
 }
+
+object ZoneTransferRequestUpdate {
+  implicit val codec: Codec.AsObject[ZoneTransferRequestUpdate] = deriveCodec[ZoneTransferRequestUpdate](renaming.snakeCase)
+}
+
+case class ZoneTransferRequestUpdate(
+  description: Option[String],
+  targetProjectId: Option[String]
+)
 
 case class ZoneTransferRequestCreate(
   description: String,

--- a/src/main/scala/pt/tecnico/dsi/designate/services/ZoneTransferRequests.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/services/ZoneTransferRequests.scala
@@ -2,11 +2,11 @@ package pt.tecnico.dsi.designate.services
 
 import cats.effect.Sync
 import fs2.Stream
-import io.circe.{Codec, Decoder, Encoder}
+import io.circe.{Decoder, Codec, Encoder}
 import io.circe.syntax._
 import org.http4s.client.Client
 import org.http4s.{Header, Query, Uri}
-import pt.tecnico.dsi.designate.models.{Status, WithId, ZoneTransferRequest, ZoneTransferRequestCreate}
+import pt.tecnico.dsi.designate.models.{Status, WithId, ZoneTransferRequest, ZoneTransferRequestCreate, ZoneTransferRequestUpdate}
 
 final class ZoneTransferRequests[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F])
   extends BaseService[F](authToken) {
@@ -14,7 +14,7 @@ final class ZoneTransferRequests[F[_]: Sync](baseUri: Uri, authToken: Header)(im
   // We cannot extend crud service directly because `create` does not belong to uri
   def crudService: AsymmetricCRUDService[F, ZoneTransferRequest] =
     new AsymmetricCRUDService[F, ZoneTransferRequest](baseUri, name = "transfer_request", authToken) {
-      override type Update = ZoneTransferRequestCreate
+      override type Update = ZoneTransferRequestUpdate
   }
 
   def get(id: String): F[WithId[ZoneTransferRequest]] = crudService.get(id)

--- a/src/main/scala/pt/tecnico/dsi/designate/services/ZoneTransferRequests.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/services/ZoneTransferRequests.scala
@@ -2,14 +2,33 @@ package pt.tecnico.dsi.designate.services
 
 import cats.effect.Sync
 import fs2.Stream
+import io.circe.{Codec, Decoder, Encoder}
 import io.circe.syntax._
 import org.http4s.client.Client
 import org.http4s.{Header, Query, Uri}
-import pt.tecnico.dsi.designate.models.{Status, WithId, ZoneTransferRequest}
+import pt.tecnico.dsi.designate.models.{Status, WithId, ZoneTransferRequest, ZoneTransferRequestCreate}
 
 final class ZoneTransferRequests[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F])
-  extends CRUDService[F, ZoneTransferRequest](baseUri / "transfer_requests", name = "transfer_request", authToken) {
+  extends BaseService[F](authToken) {
 
-  def list(status: Status): Stream[F, WithId[ZoneTransferRequest]] =
-    list(Query.fromPairs("status" -> status.asJson.toString()))
+  // We cannot extend crud service directly because `create` does not belong to uri
+  def crudService: AsymmetricCRUDService[F, ZoneTransferRequest] =
+    new AsymmetricCRUDService[F, ZoneTransferRequest](baseUri, name = "transfer_request", authToken) {
+      override type Update = ZoneTransferRequestCreate
+  }
+
+  def get(id: String): F[WithId[ZoneTransferRequest]] = crudService.get(id)
+
+  def delete(id: String): F[Unit] = delete(uri / id)
+
+  def list(query: Query): Stream[F, WithId[ZoneTransferRequest]] = crudService.list(query)
+  def list(): Stream[F, WithId[ZoneTransferRequest]] = crudService.list()
+
+  def list(status: Option[Status]): Stream[F, WithId[ZoneTransferRequest]] =
+    crudService.list(Query.fromPairs("status" -> status.asJson.toString()))
+
+  def update(id: String, value: ZoneTransferRequestCreate)(implicit c: Codec[ZoneTransferRequestCreate]): F[WithId[ZoneTransferRequest]]
+    = crudService.update(id, value)
+
+  override val uri: Uri = baseUri / "transfer_requests"
 }

--- a/src/main/scala/pt/tecnico/dsi/designate/services/Zones.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/services/Zones.scala
@@ -7,7 +7,7 @@ import cats.syntax.flatMap._
 import org.http4s.Status.{Conflict, Successful}
 import org.http4s.client.{Client, UnexpectedStatus}
 import org.http4s.{Header, Query, Response, Status, Uri}
-import pt.tecnico.dsi.designate.models.{Nameserver, WithId, Zone, ZoneCreate, ZoneUpdate}
+import pt.tecnico.dsi.designate.models.{Nameserver, WithId, Zone, ZoneCreate, ZoneTransferRequest, ZoneTransferRequestCreate, ZoneUpdate}
 
 final class Zones[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
   extends AsymmetricCRUDService[F, Zone](baseUri, "zone", authToken) {
@@ -46,6 +46,22 @@ final class Zones[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
 
   object tasks {
     val uri: Uri = self.uri / "tasks"
+
+    def createTransferRequest(zoneId: String, value: ZoneTransferRequestCreate): F[WithId[ZoneTransferRequest]] =
+      createTransferRequestHandleConflict(self.uri / zoneId / "tasks" / "transfer_requests", value) { _ =>
+        transferRequests.list().filter(h => h.zoneId == zoneId)
+          .head.compile.lastOrError
+          .flatMap(existing => transferRequests.update(existing.id, value))
+      }
+
+    protected def createTransferRequestHandleConflict(uri: Uri, value: ZoneTransferRequestCreate)(onConflict: Response[F] => F[WithId[ZoneTransferRequest]])
+      : F[WithId[ZoneTransferRequest]] =
+      client.fetch(POST(value, uri, authToken)) {
+        case Successful(response) => response.as[WithId[ZoneTransferRequest]]
+        case Conflict(response) => onConflict(response)
+        case response => F.raiseError(UnexpectedStatus(response.status))
+      }
+
     val transferRequests: ZoneTransferRequests[F] = new ZoneTransferRequests(uri, authToken)
     val transferAccepts: ZoneTransferAccepts[F] = new ZoneTransferAccepts(uri, authToken)
   }

--- a/src/main/scala/pt/tecnico/dsi/designate/services/Zones.scala
+++ b/src/main/scala/pt/tecnico/dsi/designate/services/Zones.scala
@@ -7,7 +7,7 @@ import cats.syntax.flatMap._
 import org.http4s.Status.{Conflict, Successful}
 import org.http4s.client.{Client, UnexpectedStatus}
 import org.http4s.{Header, Query, Response, Status, Uri}
-import pt.tecnico.dsi.designate.models.{Nameserver, WithId, Zone, ZoneCreate, ZoneTransferRequest, ZoneTransferRequestCreate, ZoneUpdate}
+import pt.tecnico.dsi.designate.models.{Nameserver, WithId, Zone, ZoneCreate, ZoneTransferRequest, ZoneTransferRequestCreate, ZoneTransferRequestUpdate, ZoneUpdate}
 
 final class Zones[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
   extends AsymmetricCRUDService[F, Zone](baseUri, "zone", authToken) {
@@ -47,15 +47,18 @@ final class Zones[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
   object tasks {
     val uri: Uri = self.uri / "tasks"
 
-    def createTransferRequest(zoneId: String, value: ZoneTransferRequestCreate): F[WithId[ZoneTransferRequest]] =
+    def createTransferRequest(zoneId: String, value: ZoneTransferRequestCreate)(implicit c: Codec[ZoneTransferRequestUpdate], d: Codec[ZoneTransferRequestCreate]): F[WithId[ZoneTransferRequest]] =
       createTransferRequestHandleConflict(self.uri / zoneId / "tasks" / "transfer_requests", value) { _ =>
         transferRequests.list().filter(h => h.zoneId == zoneId)
           .head.compile.lastOrError
-          .flatMap(existing => transferRequests.update(existing.id, value))
+          .flatMap(existing => transferRequests.update(existing.id, ZoneTransferRequestUpdate(
+            description = Some(value.description),
+            targetProjectId = value.targetProjectId
+          )))
       }
 
     protected def createTransferRequestHandleConflict(uri: Uri, value: ZoneTransferRequestCreate)(onConflict: Response[F] => F[WithId[ZoneTransferRequest]])
-      : F[WithId[ZoneTransferRequest]] =
+      (implicit c: Codec[ZoneTransferRequestCreate]): F[WithId[ZoneTransferRequest]] =
       client.fetch(POST(value, uri, authToken)) {
         case Successful(response) => response.as[WithId[ZoneTransferRequest]]
         case Conflict(response) => onConflict(response)

--- a/src/test/scala/pt/tecnico/dsi/designate/QuotasSpec.scala
+++ b/src/test/scala/pt/tecnico/dsi/designate/QuotasSpec.scala
@@ -25,7 +25,7 @@ class QuotasSpec extends Utils {
       for {
         keystone <- keystoneClient
         client <- designateClient
-        project <- keystone.projects.list().head.compile.lastOrError
+        project <- keystone.projects.get("admin", keystone.session.user.domainId)
         _ <- client.quotas.reset(project.id)
         quota <- client.quotas.get(project.id)
         isIdempotent <- client.quotas.get(project.id).valueShouldIdempotentlyBe(quota)
@@ -35,7 +35,7 @@ class QuotasSpec extends Utils {
     "get project quotas" in {
       for {
         keystone <- keystoneClient
-        project <- keystone.projects.list().head.compile.lastOrError
+        project <- keystone.projects.get("admin", keystone.session.user.domainId)
         client <- designateClient
         actual <- client.quotas.get(project.id)
         isIdempotent <- client.quotas.get(project.id).valueShouldIdempotentlyBe(actual)
@@ -53,7 +53,7 @@ class QuotasSpec extends Utils {
     "set project quotas" in {
       for {
         keystone <- keystoneClient
-        project <- keystone.projects.list().head.compile.lastOrError
+        project <- keystone.projects.get("admin", keystone.session.user.domainId)
         client <- designateClient
         isIdempotent <- client.quotas.update(project.id, dummyQuota).valueShouldIdempotentlyBe(dummyQuota)
       } yield isIdempotent

--- a/src/test/scala/pt/tecnico/dsi/designate/ZoneTransferAcceptsSpec.scala
+++ b/src/test/scala/pt/tecnico/dsi/designate/ZoneTransferAcceptsSpec.scala
@@ -1,12 +1,58 @@
 package pt.tecnico.dsi.designate
 
+import pt.tecnico.dsi.designate.models.{ZoneCreate, ZoneTransferRequestCreate}
+
 class ZoneTransferAcceptsSpec extends Utils {
   "Zone Transfer Accept service" should {
+
+    val dummyZoneCreate = ZoneCreate(
+      name = "example.org.",
+      email = "joe@example.org"
+    )
+
+    val dummyZoneTransferRequestCreate = ZoneTransferRequestCreate(
+      description = "This is a zone transfer request.",
+      targetProjectId = None
+    )
+
+    "create zone transfer accept" in {
+      for {
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        req <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+        acc <- client.zones.tasks.transferAccepts.create(req.key, req.id)
+      } yield acc.zoneId shouldEqual zone.id
+    }
+
     "list zone transfer accepts" in {
       for {
-        designate <- designateClient
-        _ <- designate.zones.tasks.transferAccepts.list.compile.toList
-      } yield assert(true)
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        req <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+        acc <- client.zones.tasks.transferAccepts.create(req.key, req.id)
+        got <- client.zones.tasks.transferAccepts.list.filter(_.id == acc.id).head.compile.lastOrError
+      } yield
+        assert {
+          /* For some reason `key` is None on `list` but not on `create`
+             The docs say: Key that is used as part of the zone transfer accept process.
+             This is only shown to the creator, and must be communicated out of band.
+           */
+          (got.id == acc.id) && (got.model.copy(`key` = None) == acc.model.copy(`key` = None))
+        }
     }
+
+    "get zone transfer accept" in {
+      for {
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        req <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+        expected <- client.zones.tasks.transferAccepts.create(req.key, req.id)
+        actual <- client.zones.tasks.transferAccepts.get(expected.id)
+      } yield assert {
+        expected.id == actual.id &&
+        expected.model.copy(`key` = None) == actual.model.copy(`key` = None)
+      }
+    }
+
   }
 }

--- a/src/test/scala/pt/tecnico/dsi/designate/ZoneTransferRequestsSpec.scala
+++ b/src/test/scala/pt/tecnico/dsi/designate/ZoneTransferRequestsSpec.scala
@@ -1,6 +1,62 @@
 package pt.tecnico.dsi.designate
 
+import pt.tecnico.dsi.designate.models.{ZoneCreate, ZoneTransferRequestCreate}
+
 class ZoneTransferRequestsSpec extends Utils {
   "Zone Tranfer Requests Service" should {
+
+    val dummyZoneCreate = ZoneCreate(
+      name = "example.org.",
+      email = "joe@example.org"
+    )
+
+    val dummyZoneTransferRequestCreate = ZoneTransferRequestCreate(
+      description = "This is a zone transfer request.",
+      targetProjectId = None
+    )
+
+    val dummyZoneTransferRequestUpdate = ZoneTransferRequestCreate(
+      description = "This is a zone transfer request after update.",
+      targetProjectId = None
+    )
+
+    "create zone transfer request" in {
+      for {
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        req <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+      } yield req.zoneId shouldEqual zone.id
+    }
+
+    "update zone transfer request" in {
+      for {
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        before <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+        actual <- client.zones.tasks.transferRequests.update(before.id, dummyZoneTransferRequestUpdate)
+      } yield assert {
+        actual.description == dummyZoneTransferRequestUpdate.description &&
+        actual.targetProjectId == dummyZoneTransferRequestUpdate.targetProjectId
+      }
+    }
+
+    "get zone transfer request" in {
+      for {
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        expected <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+        actual <- client.zones.tasks.transferRequests.get(expected.id)
+      } yield actual shouldEqual expected
+    }
+
+    "delete zone transfer request" in {
+      for {
+        client <- designateClient
+        zone <- client.zones.create(dummyZoneCreate)
+        expected <- client.zones.tasks.createTransferRequest(zone.id, dummyZoneTransferRequestCreate)
+        _ <- client.zones.tasks.transferRequests.delete(expected.id)
+        found <- client.zones.tasks.transferRequests.list().filter(_.id == expected.id).head.compile.last
+      } yield found shouldEqual None
+    }
   }
 }


### PR DESCRIPTION
- `BaseService` needs lots of refactoring.
- `Recordsets` are still throwing `400 Bad Request` once in a while.
-  Endpoint for creating `ZoneTransferRequest` doesn't have the same prefix as the rest of the endpoints, so I put inside `Zones` class, but there might be better options.